### PR TITLE
V3 oauth grooming

### DIFF
--- a/source/includes/_api_oauth_tokens.md
+++ b/source/includes/_api_oauth_tokens.md
@@ -61,6 +61,7 @@ There is no undo, so be sure before you delete an account. You can also use the 
 
 <img src="../assets/store-api-accounts.png" alt="Creating an API account" height=100% width=100%>
 
+
 ## <span class="jumptarget" id="request_oauth"> OAuth API Requests </span>
 
 To see how to quickly make initial OAuth requests using the <a href="https://www.getpostman.com/" target="_blank">Postman app</a>, please see our [Postman/OAuth Quickstart Guide](#postman_qs).

--- a/source/includes/_api_oauth_tokens.md
+++ b/source/includes/_api_oauth_tokens.md
@@ -2,9 +2,9 @@
 
 You have two options for obtaining and managing credentials that will connect your app with your BigCommerce store:
 
-* [Obtaining OAuth Tokens](#cp_oauth_get): We recommend OAuth, because this authentication method is compatible with all current and planned BigCommerce APIs. Also, OAuth is required for apps intended to be [sold on the BigCommerce App Marketplace](#).
+* [Obtaining OAuth Tokens](#cp_oauth_get): We recommend OAuth, because this authentication method is compatible with all current and planned BigCommerce APIs. Also, OAuth is required for apps intended to be <a href="https://www.bigcommerce.com/apps/" target="_blank">sold on the BigCommerce App Marketplace</a>.
 
-* [Creating Basic Auth Credentials](#basiccred): Basic Auth is still supported as a legacy option for [private apps](##building-basic-auth-apps) (apps developed for a single BigCommerce store). However, although Basic Auth is compatible with most of our v2 API, it is inccompatible with [webhooks](##webhooks-overview), and incompatible with our <a href="https://github.com/bigcommerce/api/blob/master/docs/v3-catalog.md" target="_blank">v3 API</a>.
+* [Creating Basic-Auth Credentials](#basiccred): Basic Auth is still supported as a legacy option for connecting with most of our v2 API. (You can find details about the Basic-Auth workflow [here](#building-apps-with-basic-auth).) However, Basic Auth is not compatible with [webhooks](#webhooks-overview), and is not compatible with our <a href="https://github.com/bigcommerce/api/blob/master/docs/v3-catalog.md" target="_blank">v3 API</a>.
 
 
 # <span class="jumptarget" id="cp_oauth_manage"> Authenticating with OAuth </span>

--- a/source/includes/_changelog_2017.md
+++ b/source/includes/_changelog_2017.md
@@ -1,6 +1,14 @@
 # <span class="jumptarget"> 2017 </span>
 
 
+## <span class="jumptarget"> February </span>
+
+
+### <span class="jumptarget"> Stencil Cornerstone 1.5.0 Theme Released </span>
+
+Version [1.5.0](https://stencil.bigcommerce.com/docs/release-notes-cornerstone-15-theme) of Stencil's default Cornerstone theme is now available. This release adds several new options for store owners to customize their store's appearance via Theme Editor. These options include displaying sale badges, displaying "as low as $x" pricing, and requiring customer logins for pricing and cart access. It also corrects the behavior of hashbang links (`#!`), and corrects the display of product options in Quick View modals. For the PR #'s/commit #'s to cherry-pick the hashbang fix, please see the <a href="https://stencil.bigcommerce.com/docs/release-notes" target="_blank">Stencil framework release notes</a>.
+
+
 ## <span class="jumptarget"> January </span>
 
 

--- a/source/includes/_themes_checkout_styling.md
+++ b/source/includes/_themes_checkout_styling.md
@@ -2,6 +2,13 @@
 
 To support stores that enable BigCommerce's Optimized One-Page Checkout feature, you can customize the Optimized Checkout page's styling within your theme. You do this by adding custom CSS to the `optimized-checkout-webdav.css` template file that we provide. You can download the template as a <a href="/assets/optimized-checkout-webdav.css.zip">.zip file here</a>, or copy the CSS [below](#uco-css-skeleton).
 
+<aside class="success">
+<span class="success-warning-hd">Function Names</span><br><br>
+Although you will see references to "Stencil" functions throughout this template file's CSS, this version of the CSS is designed to be fully compatible with Blueprint themes.
+</aside>
+
+
+
 ## <span class="jumptarget"> Customization Options/Restrictions </span>
 
 As a theme developer, you are free to change classes' contents – but do not nest elements, nor change any class names. 

--- a/source/includes/_v3_catalog_customer_complete.md
+++ b/source/includes/_v3_catalog_customer_complete.md
@@ -1286,7 +1286,8 @@ Please view the documentation generated from the Swagger file [here](http://edit
     </a>
    </li>
   </ul>
-  <h1 id= "Catalog" class="jumptarget"> Catalog </h1>
+  <h1 id= "Catalog" class="jumptarget"> Catalog Methods/Endpoints </h1>
+  <h2 id= "Catalog_descrip" class="jumptarget"> Methods – Descriptions </h2>
   <div class="method">
    <a name="catalogSummaryGet">
    </a>
@@ -12387,7 +12388,8 @@ Values: id, name, sku, price, date_modified, date_last_imported, inventory_level
    </a>
   </div>
   <hr/>
-  <h1 id= "Customers" class="jumptarget"> Customers </h1>
+  <h1 id= "Customers" class="jumptarget"> Customers Methods/Endpoints </h1>
+    <h2 id= "Customers_descrip" class="jumptarget"> Methods – Descriptions </h2>
   <div class="method">
    <a name="createSubscriber">
    </a>
@@ -13658,7 +13660,9 @@ Values: id, name, sku, price, date_modified, date_last_imported, inventory_level
     </a>
    </li>
   </ol>
+<h2 id="models_descrip" class="jumptarget"> Models – Descriptions </h2>
   <div class="model">
+   </p>
    <h3 class="field-label">
     <a name="Adjuster">
      Adjuster
@@ -13667,7 +13671,7 @@ Values: id, name, sku, price, date_modified, date_last_imported, inventory_level
    <div class="model-description">
    </div>
    <br/>
-   <div class="field-items">
+   <div class="field-items"> <b>Properties:</b>
     </p><div class="param">
      adjuster (optional)
     </div>
@@ -13702,6 +13706,7 @@ Values: id, name, sku, price, date_modified, date_last_imported, inventory_level
    </div>
   </div>
   <div class="model">
+   </p>
    <h3 class="field-label">
     <a name="BaseError">
      BaseError
@@ -13711,7 +13716,7 @@ Values: id, name, sku, price, date_modified, date_last_imported, inventory_level
     Error payload for the BigCommerce API.
    </div>
    <br/>
-   <div class="field-items">
+   <div class="field-items"><b>Properties:</b>
     </p><div class="param">
      status (optional)
     </div>
@@ -13757,6 +13762,7 @@ Values: id, name, sku, price, date_modified, date_last_imported, inventory_level
    </div>
   </div>
   <div class="model">
+   </p>
    <h3 class="field-label">
     <a name="Brand">
      Brand
@@ -13765,7 +13771,7 @@ Values: id, name, sku, price, date_modified, date_last_imported, inventory_level
    <div class="model-description">
    </div>
    <br/>
-   <div class="field-items">
+   <div class="field-items"> <b>Properties:</b>
     </p><div class="param">
      id (optional)
     </div>
@@ -13846,6 +13852,7 @@ Values: id, name, sku, price, date_modified, date_last_imported, inventory_level
    </div>
   </div>
   <div class="model">
+   </p>
    <h3 class="field-label">
     <a name="BrandCollectionResponse">
      BrandCollectionResponse
@@ -13855,7 +13862,7 @@ Values: id, name, sku, price, date_modified, date_last_imported, inventory_level
     Response payload for the Bigcommerce API.
    </div>
    <br/>
-   <div class="field-items">
+   <div class="field-items"> <b>Properties:</b>
     </p><div class="param">
      data (optional)
     </div>
@@ -13879,6 +13886,7 @@ Values: id, name, sku, price, date_modified, date_last_imported, inventory_level
    </div>
   </div>
   <div class="model">
+   </p>
    <h3 class="field-label">
     <a name="BrandResponse">
      BrandResponse
@@ -13888,7 +13896,7 @@ Values: id, name, sku, price, date_modified, date_last_imported, inventory_level
     Response payload for the Bigcommerce API.
    </div>
    <br/>
-   <div class="field-items">
+   <div class="field-items"> <b>Properties:</b>
     </p><div class="param">
      data (optional)
     </div>
@@ -13912,6 +13920,7 @@ Values: id, name, sku, price, date_modified, date_last_imported, inventory_level
    </div>
   </div>
   <div class="model">
+   </p>
    <h3 class="field-label">
     <a name="BulkPricingRule">
      BulkPricingRule
@@ -13921,7 +13930,7 @@ Values: id, name, sku, price, date_modified, date_last_imported, inventory_level
     Rules that offer price discounts based on quantity breaks.
    </div>
    <br/>
-   <div class="field-items">
+   <div class="field-items"> <b>Properties:</b>
     </p><div class="param">
      id (optional)
     </div>
@@ -13993,6 +14002,7 @@ Values: id, name, sku, price, date_modified, date_last_imported, inventory_level
    </div>
   </div>
   <div class="model">
+   </p>
    <h3 class="field-label">
     <a name="CatalogSummary">
      CatalogSummary
@@ -14002,7 +14012,7 @@ Values: id, name, sku, price, date_modified, date_last_imported, inventory_level
     A BigCommerce Catalog Summary object describes a lightweight summary of the catalog.
    </div>
    <br/>
-   <div class="field-items">
+   <div class="field-items"> <b>Properties:</b>
     </p><div class="param">
      inventory_count (optional)
     </div>
@@ -14051,6 +14061,7 @@ Values: id, name, sku, price, date_modified, date_last_imported, inventory_level
    </div>
   </div>
   <div class="model">
+   </p>
    <h3 class="field-label">
     <a name="CatalogSummaryResponse">
      CatalogSummaryResponse
@@ -14060,7 +14071,7 @@ Values: id, name, sku, price, date_modified, date_last_imported, inventory_level
     Response payload for the Bigcommerce API.
    </div>
    <br/>
-   <div class="field-items">
+   <div class="field-items"> <b>Properties:</b>
     </p><div class="param">
      data (optional)
     </div>
@@ -14084,6 +14095,7 @@ Values: id, name, sku, price, date_modified, date_last_imported, inventory_level
    </div>
   </div>
   <div class="model">
+   </p>
    <h3 class="field-label">
     <a name="Category">
      Category
@@ -14093,7 +14105,7 @@ Values: id, name, sku, price, date_modified, date_last_imported, inventory_level
     A BigCommerce category object.
    </div>
    <br/>
-   <div class="field-items">
+   <div class="field-items"> <b>Properties:</b>
     </p><div class="param">
      id (optional)
     </div>
@@ -14291,6 +14303,7 @@ Values: id, name, sku, price, date_modified, date_last_imported, inventory_level
    </div>
   </div>
   <div class="model">
+   </p>
    <h3 class="field-label">
     <a name="CategoryCollectionResponse">
      CategoryCollectionResponse
@@ -14300,7 +14313,7 @@ Values: id, name, sku, price, date_modified, date_last_imported, inventory_level
     Response payload for the Bigcommerce API.
    </div>
    <br/>
-   <div class="field-items">
+   <div class="field-items"> <b>Properties:</b>
     </p><div class="param">
      data (optional)
     </div>
@@ -14324,6 +14337,7 @@ Values: id, name, sku, price, date_modified, date_last_imported, inventory_level
    </div>
   </div>
   <div class="model">
+   </p>
    <h3 class="field-label">
     <a name="CategoryNode">
      CategoryNode
@@ -14333,7 +14347,7 @@ Values: id, name, sku, price, date_modified, date_last_imported, inventory_level
     A BigCommerce category node object. Used to reflect parent &lt;&gt; child category relationships.
    </div>
    <br/>
-   <div class="field-items">
+   <div class="field-items"> <b>Properties:</b>
     </p><div class="param">
      id (optional)
     </div>
@@ -14403,6 +14417,7 @@ Values: id, name, sku, price, date_modified, date_last_imported, inventory_level
    </div>
   </div>
   <div class="model">
+   </p>
    <h3 class="field-label">
     <a name="CategoryResponse">
      CategoryResponse
@@ -14412,7 +14427,7 @@ Values: id, name, sku, price, date_modified, date_last_imported, inventory_level
     Response payload for the Bigcommerce API.
    </div>
    <br/>
-   <div class="field-items">
+   <div class="field-items"> <b>Properties:</b>
     </p><div class="param">
      data (optional)
     </div>
@@ -14436,6 +14451,7 @@ Values: id, name, sku, price, date_modified, date_last_imported, inventory_level
    </div>
   </div>
   <div class="model">
+   </p>
    <h3 class="field-label">
     <a name="CategoryTreeCollectionResponse">
      CategoryTreeCollectionResponse
@@ -14445,7 +14461,7 @@ Values: id, name, sku, price, date_modified, date_last_imported, inventory_level
     Response payload for the Bigcommerce API.
    </div>
    <br/>
-   <div class="field-items">
+   <div class="field-items"> <b>Properties:</b>
     </p><div class="param">
      data (optional)
     </div>
@@ -14469,6 +14485,7 @@ Values: id, name, sku, price, date_modified, date_last_imported, inventory_level
    </div>
   </div>
   <div class="model">
+   </p>
    <h3 class="field-label">
     <a name="CollectionMeta">
      CollectionMeta
@@ -14478,7 +14495,7 @@ Values: id, name, sku, price, date_modified, date_last_imported, inventory_level
     Data about the response, including pagination and collection totals.
    </div>
    <br/>
-   <div class="field-items">
+   <div class="field-items"> <b>Properties:</b>
     </p><div class="param">
      total (optional)
     </div>
@@ -14547,6 +14564,7 @@ Values: id, name, sku, price, date_modified, date_last_imported, inventory_level
    </div>
   </div>
   <div class="model">
+   </p>
    <h3 class="field-label">
     <a name="CollectionMeta_links">
      CollectionMeta_links
@@ -14556,7 +14574,7 @@ Values: id, name, sku, price, date_modified, date_last_imported, inventory_level
     Pagination links for the previous and next parts of the whole collection.
    </div>
    <br/>
-   <div class="field-items">
+   <div class="field-items"> <b>Properties:</b>
     </p><div class="param">
      previous (optional)
     </div>
@@ -14593,6 +14611,7 @@ Values: id, name, sku, price, date_modified, date_last_imported, inventory_level
    </div>
   </div>
   <div class="model">
+   </p>
    <h3 class="field-label">
     <a name="ComplexRule">
      ComplexRule
@@ -14602,7 +14621,7 @@ Values: id, name, sku, price, date_modified, date_last_imported, inventory_level
     Apply price, weight, image, or availabilty adjustments to product, based on a set of conditions. A complex rule's condition must either contain more than one modifier value, or else contain a modifier value and a variant id.
    </div>
    <br/>
-   <div class="field-items">
+   <div class="field-items"> <b>Properties:</b>
     </p><div class="param">
      id (optional)
     </div>
@@ -14735,6 +14754,7 @@ Values: id, name, sku, price, date_modified, date_last_imported, inventory_level
    </div>
   </div>
   <div class="model">
+   </p>
    <h3 class="field-label">
     <a name="ComplexRuleCollectionResponse">
      ComplexRuleCollectionResponse
@@ -14744,7 +14764,7 @@ Values: id, name, sku, price, date_modified, date_last_imported, inventory_level
     Response payload for the Bigcommerce API.
    </div>
    <br/>
-   <div class="field-items">
+   <div class="field-items"> <b>Properties:</b>
     </p><div class="param">
      data (optional)
     </div>
@@ -14768,6 +14788,7 @@ Values: id, name, sku, price, date_modified, date_last_imported, inventory_level
    </div>
   </div>
   <div class="model">
+   </p>
    <h3 class="field-label">
     <a name="ComplexRuleCondition">
      ComplexRuleCondition
@@ -14777,7 +14798,7 @@ Values: id, name, sku, price, date_modified, date_last_imported, inventory_level
     Complex rules may return with conditions that apply to one or more variants, or with a single modifier value (if the rules were created using the v2 API or the control panel). Complex rules created or updated in the v3 API must have conditions that either reference multiple `modifier_value_id`'s, or else reference a `modifier_value_id` and a `variant_id`.
    </div>
    <br/>
-   <div class="field-items">
+   <div class="field-items"> <b>Properties:</b>
     </p><div class="param">
      id (optional)
     </div>
@@ -14847,6 +14868,7 @@ Values: id, name, sku, price, date_modified, date_last_imported, inventory_level
    </div>
   </div>
   <div class="model">
+   </p>
    <h3 class="field-label">
     <a name="ComplexRuleResponse">
      ComplexRuleResponse
@@ -14856,7 +14878,7 @@ Values: id, name, sku, price, date_modified, date_last_imported, inventory_level
     Response payload for the Bigcommerce API.
    </div>
    <br/>
-   <div class="field-items">
+   <div class="field-items"> <b>Properties:</b>
     </p><div class="param">
      data (optional)
     </div>
@@ -14880,6 +14902,7 @@ Values: id, name, sku, price, date_modified, date_last_imported, inventory_level
    </div>
   </div>
   <div class="model">
+   </p>
    <h3 class="field-label">
     <a name="CustomField">
      CustomField
@@ -14889,7 +14912,7 @@ Values: id, name, sku, price, date_modified, date_last_imported, inventory_level
     Gets custom fields associated with a product. These allow you to specify additional information that will appear on the product's page, such as a book's ISBN or a DVD's release date.
    </div>
    <br/>
-   <div class="field-items">
+   <div class="field-items"> <b>Properties:</b>
     </p><div class="param">
      id (optional)
     </div>
@@ -14937,6 +14960,7 @@ Values: id, name, sku, price, date_modified, date_last_imported, inventory_level
    </div>
   </div>
   <div class="model">
+   </p>
    <h3 class="field-label">
     <a name="CustomUrl">
      CustomUrl
@@ -14946,7 +14970,7 @@ Values: id, name, sku, price, date_modified, date_last_imported, inventory_level
     The custom URL for the product on the storefront.
    </div>
    <br/>
-   <div class="field-items">
+   <div class="field-items"> <b>Properties:</b>
     </p><div class="param">
      url (optional)
     </div>
@@ -14972,6 +14996,7 @@ Values: id, name, sku, price, date_modified, date_last_imported, inventory_level
    </div>
   </div>
   <div class="model">
+   </p>
    <h3 class="field-label">
     <a name="DetailedErrors">
      DetailedErrors
@@ -14984,6 +15009,7 @@ Values: id, name, sku, price, date_modified, date_last_imported, inventory_level
    </div>
   </div>
   <div class="model">
+   </p>
    <h3 class="field-label">
     <a name="ErrorResponse">
      ErrorResponse
@@ -14992,7 +15018,7 @@ Values: id, name, sku, price, date_modified, date_last_imported, inventory_level
    <div class="model-description">
    </div>
    <br/>
-   <div class="field-items">
+   <div class="field-items"> <b>Properties:</b>
     </p><div class="param">
      status (optional)
     </div>
@@ -15048,6 +15074,7 @@ Values: id, name, sku, price, date_modified, date_last_imported, inventory_level
    </div>
   </div>
   <div class="model">
+   </p>
    <h3 class="field-label">
     <a name="ImageResponse">
      ImageResponse
@@ -15057,7 +15084,7 @@ Values: id, name, sku, price, date_modified, date_last_imported, inventory_level
     Response payload for the Bigcommerce API.
    </div>
    <br/>
-   <div class="field-items">
+   <div class="field-items"> <b>Properties:</b>
     </p><div class="param">
      data (optional)
     </div>
@@ -15081,6 +15108,7 @@ Values: id, name, sku, price, date_modified, date_last_imported, inventory_level
    </div>
   </div>
   <div class="model">
+   </p>
    <h3 class="field-label">
     <a name="Meta">
      Meta
@@ -15094,6 +15122,7 @@ Values: id, name, sku, price, date_modified, date_last_imported, inventory_level
    </div>
   </div>
   <div class="model">
+   </p>
    <h3 class="field-label">
     <a name="MetaFieldCollectionResponse">
      MetaFieldCollectionResponse
@@ -15103,7 +15132,7 @@ Values: id, name, sku, price, date_modified, date_last_imported, inventory_level
     Response payload for the Bigcommerce API.
    </div>
    <br/>
-   <div class="field-items">
+   <div class="field-items"> <b>Properties:</b>
     </p><div class="param">
      data (optional)
     </div>
@@ -15127,6 +15156,7 @@ Values: id, name, sku, price, date_modified, date_last_imported, inventory_level
    </div>
   </div>
   <div class="model">
+   </p>
    <h3 class="field-label">
     <a name="Metafield">
      Metafield
@@ -15136,7 +15166,7 @@ Values: id, name, sku, price, date_modified, date_last_imported, inventory_level
     Allows app partners to write custom data to various resources in the API.
    </div>
    <br/>
-   <div class="field-items">
+   <div class="field-items"> <b>Properties:</b>
     </p><div class="param">
      id (optional)
     </div>
@@ -15279,6 +15309,7 @@ Values: id, name, sku, price, date_modified, date_last_imported, inventory_level
    </div>
   </div>
   <div class="model">
+   </p>
    <h3 class="field-label">
     <a name="MetafieldResponse">
      MetafieldResponse
@@ -15288,7 +15319,7 @@ Values: id, name, sku, price, date_modified, date_last_imported, inventory_level
     Response payload for the Bigcommerce API.
    </div>
    <br/>
-   <div class="field-items">
+   <div class="field-items"> <b>Properties:</b>
     </p><div class="param">
      data (optional)
     </div>
@@ -15312,6 +15343,7 @@ Values: id, name, sku, price, date_modified, date_last_imported, inventory_level
    </div>
   </div>
   <div class="model">
+   </p>
    <h3 class="field-label">
     <a name="Modifier">
      Modifier
@@ -15320,7 +15352,7 @@ Values: id, name, sku, price, date_modified, date_last_imported, inventory_level
    <div class="model-description">
    </div>
    <br/>
-   <div class="field-items">
+   <div class="field-items"> <b>Properties:</b>
     </p><div class="param">
      id (optional)
     </div>
@@ -15451,6 +15483,7 @@ RT = rectangles, S = dropdown, P = product_list, PI = product_list_with_images, 
    </div>
   </div>
   <div class="model">
+   </p>
    <h3 class="field-label">
     <a name="ModifierCollectionResponse">
      ModifierCollectionResponse
@@ -15460,7 +15493,7 @@ RT = rectangles, S = dropdown, P = product_list, PI = product_list_with_images, 
     Response payload for the Bigcommerce API.
    </div>
    <br/>
-   <div class="field-items">
+   <div class="field-items"> <b>Properties:</b>
     </p><div class="param">
      data (optional)
     </div>
@@ -15484,6 +15517,7 @@ RT = rectangles, S = dropdown, P = product_list, PI = product_list_with_images, 
    </div>
   </div>
   <div class="model">
+   </p>
    <h3 class="field-label">
     <a name="ModifierResponse">
      ModifierResponse
@@ -15493,7 +15527,7 @@ RT = rectangles, S = dropdown, P = product_list, PI = product_list_with_images, 
     Response payload for the Bigcommerce API.
    </div>
    <br/>
-   <div class="field-items">
+   <div class="field-items"> <b>Properties:</b>
     </p><div class="param">
      data (optional)
     </div>
@@ -15517,6 +15551,7 @@ RT = rectangles, S = dropdown, P = product_list, PI = product_list_with_images, 
    </div>
   </div>
   <div class="model">
+   </p>
    <h3 class="field-label">
     <a name="ModifierValue">
      ModifierValue
@@ -15525,7 +15560,7 @@ RT = rectangles, S = dropdown, P = product_list, PI = product_list_with_images, 
    <div class="model-description">
    </div>
    <br/>
-   <div class="field-items">
+   <div class="field-items"> <b>Properties:</b>
     </p><div class="param">
      id (optional)
     </div>
@@ -15594,6 +15629,7 @@ RT = rectangles, S = dropdown, P = product_list, PI = product_list_with_images, 
    </div>
   </div>
   <div class="model">
+   </p>
    <h3 class="field-label">
     <a name="ModifierValue_adjusters">
      ModifierValue_adjusters
@@ -15602,7 +15638,7 @@ RT = rectangles, S = dropdown, P = product_list, PI = product_list_with_images, 
    <div class="model-description">
    </div>
    <br/>
-   <div class="field-items">
+   <div class="field-items"> <b>Properties:</b>
     </p><div class="param">
      price (optional)
     </div>
@@ -15647,6 +15683,7 @@ RT = rectangles, S = dropdown, P = product_list, PI = product_list_with_images, 
    </div>
   </div>
   <div class="model">
+   </p>
    <h3 class="field-label">
     <a name="ModifierValue_adjusters_purchasing_disabled">
      ModifierValue_adjusters_purchasing_disabled
@@ -15655,7 +15692,7 @@ RT = rectangles, S = dropdown, P = product_list, PI = product_list_with_images, 
    <div class="model-description">
    </div>
    <br/>
-   <div class="field-items">
+   <div class="field-items"> <b>Properties:</b>
     </p><div class="param">
      status (optional)
     </div>
@@ -15681,6 +15718,7 @@ RT = rectangles, S = dropdown, P = product_list, PI = product_list_with_images, 
    </div>
   </div>
   <div class="model">
+   </p>
    <h3 class="field-label">
     <a name="NotFound">
      NotFound
@@ -15690,7 +15728,7 @@ RT = rectangles, S = dropdown, P = product_list, PI = product_list_with_images, 
     Error payload for the BigCommerce API.
    </div>
    <br/>
-   <div class="field-items">
+   <div class="field-items"> <b>Properties:</b>
     </p><div class="param">
      status (optional)
     </div>
@@ -15736,6 +15774,7 @@ RT = rectangles, S = dropdown, P = product_list, PI = product_list_with_images, 
    </div>
   </div>
   <div class="model">
+   </p>
    <h3 class="field-label">
     <a name="Option">
      Option
@@ -15744,7 +15783,7 @@ RT = rectangles, S = dropdown, P = product_list, PI = product_list_with_images, 
    <div class="model-description">
    </div>
    <br/>
-   <div class="field-items">
+   <div class="field-items"> <b>Properties:</b>
     </p><div class="param">
      id (optional)
     </div>
@@ -15845,6 +15884,7 @@ RB = radio_buttons, RT = rectangles, S = dropdown, P = product_list, PI = produc
    </div>
   </div>
   <div class="model">
+   </p>
    <h3 class="field-label">
     <a name="OptionCollectionResponse">
      OptionCollectionResponse
@@ -15854,7 +15894,7 @@ RB = radio_buttons, RT = rectangles, S = dropdown, P = product_list, PI = produc
     Response payload for the Bigcommerce API.
    </div>
    <br/>
-   <div class="field-items">
+   <div class="field-items"> <b>Properties:</b>
     </p><div class="param">
      data (optional)
     </div>
@@ -15878,6 +15918,7 @@ RB = radio_buttons, RT = rectangles, S = dropdown, P = product_list, PI = produc
    </div>
   </div>
   <div class="model">
+   </p>
    <h3 class="field-label">
     <a name="OptionConfig">
      OptionConfig
@@ -15886,7 +15927,7 @@ RB = radio_buttons, RT = rectangles, S = dropdown, P = product_list, PI = produc
    <div class="model-description">
    </div>
    <br/>
-   <div class="field-items">
+   <div class="field-items"> <b>Properties:</b>
     </p><div class="param">
      default_value (optional)
     </div>
@@ -16204,6 +16245,7 @@ RB = radio_buttons, RT = rectangles, S = dropdown, P = product_list, PI = produc
    </div>
   </div>
   <div class="model">
+   </p>
    <h3 class="field-label">
     <a name="OptionResponse">
      OptionResponse
@@ -16213,7 +16255,7 @@ RB = radio_buttons, RT = rectangles, S = dropdown, P = product_list, PI = produc
     Response payload for the Bigcommerce API.
    </div>
    <br/>
-   <div class="field-items">
+   <div class="field-items"> <b>Properties:</b>
     </p><div class="param">
      data (optional)
     </div>
@@ -16237,6 +16279,7 @@ RB = radio_buttons, RT = rectangles, S = dropdown, P = product_list, PI = produc
    </div>
   </div>
   <div class="model">
+   </p>
    <h3 class="field-label">
     <a name="OptionValue">
      OptionValue
@@ -16245,7 +16288,7 @@ RB = radio_buttons, RT = rectangles, S = dropdown, P = product_list, PI = produc
    <div class="model-description">
    </div>
    <br/>
-   <div class="field-items">
+   <div class="field-items"> <b>Properties:</b>
     </p><div class="param">
      id (optional)
     </div>
@@ -16304,6 +16347,7 @@ RB = radio_buttons, RT = rectangles, S = dropdown, P = product_list, PI = produc
    </div>
   </div>
   <div class="model">
+   </p>
    <h3 class="field-label">
     <a name="OptionValueShort">
      OptionValueShort
@@ -16312,7 +16356,7 @@ RB = radio_buttons, RT = rectangles, S = dropdown, P = product_list, PI = produc
    <div class="model-description">
    </div>
    <br/>
-   <div class="field-items">
+   <div class="field-items"> <b>Properties:</b>
     </p><div class="param">
      id (optional)
     </div>
@@ -16358,6 +16402,7 @@ RB = radio_buttons, RT = rectangles, S = dropdown, P = product_list, PI = produc
    </div>
   </div>
   <div class="model">
+   </p>
    <h3 class="field-label">
     <a name="OptionValueShortPost">
      OptionValueShortPost
@@ -16366,7 +16411,7 @@ RB = radio_buttons, RT = rectangles, S = dropdown, P = product_list, PI = produc
    <div class="model-description">
    </div>
    <br/>
-   <div class="field-items">
+   <div class="field-items"> <b>Properties:</b>
     </p><div class="param">
      option_display_name (optional)
     </div>
@@ -16392,6 +16437,7 @@ RB = radio_buttons, RT = rectangles, S = dropdown, P = product_list, PI = produc
    </div>
   </div>
   <div class="model">
+   </p>
    <h3 class="field-label">
     <a name="Product">
      Product
@@ -16401,7 +16447,7 @@ RB = radio_buttons, RT = rectangles, S = dropdown, P = product_list, PI = produc
     A BigCommerce Product object describes a single purchasable unit or a collection of purchasable units.
    </div>
    <br/>
-   <div class="field-items">
+   <div class="field-items"> <b>Properties:</b>
     </p><div class="param">
      id (optional)
     </div>
@@ -17072,6 +17118,7 @@ RB = radio_buttons, RT = rectangles, S = dropdown, P = product_list, PI = produc
    </div>
   </div>
   <div class="model">
+   </p>
    <h3 class="field-label">
     <a name="ProductCollectionResponse">
      ProductCollectionResponse
@@ -17081,7 +17128,7 @@ RB = radio_buttons, RT = rectangles, S = dropdown, P = product_list, PI = produc
     Response payload for the Bigcommerce API.
    </div>
    <br/>
-   <div class="field-items">
+   <div class="field-items"> <b>Properties:</b>
     </p><div class="param">
      data (optional)
     </div>
@@ -17105,6 +17152,7 @@ RB = radio_buttons, RT = rectangles, S = dropdown, P = product_list, PI = produc
    </div>
   </div>
   <div class="model">
+   </p>
    <h3 class="field-label">
     <a name="ProductImage">
      ProductImage
@@ -17114,7 +17162,7 @@ RB = radio_buttons, RT = rectangles, S = dropdown, P = product_list, PI = produc
     The full ProductImage model.
    </div>
    <br/>
-   <div class="field-items">
+   <div class="field-items"> <b>Properties:</b>
     </p><div class="param">
      is_thumbnail (optional)
     </div>
@@ -17228,6 +17276,7 @@ RB = radio_buttons, RT = rectangles, S = dropdown, P = product_list, PI = produc
    </div>
   </div>
   <div class="model">
+   </p>
    <h3 class="field-label">
     <a name="ProductImageBase">
      ProductImageBase
@@ -17237,7 +17286,7 @@ RB = radio_buttons, RT = rectangles, S = dropdown, P = product_list, PI = produc
     Common ProductImage properties.
    </div>
    <br/>
-   <div class="field-items">
+   <div class="field-items"> <b>Properties:</b>
     </p><div class="param">
      is_thumbnail (optional)
     </div>
@@ -17274,6 +17323,7 @@ RB = radio_buttons, RT = rectangles, S = dropdown, P = product_list, PI = produc
    </div>
   </div>
   <div class="model">
+   </p>
    <h3 class="field-label">
     <a name="ProductImageCollectionResponse">
      ProductImageCollectionResponse
@@ -17283,7 +17333,7 @@ RB = radio_buttons, RT = rectangles, S = dropdown, P = product_list, PI = produc
     Response payload for the Bigcommerce API.
    </div>
    <br/>
-   <div class="field-items">
+   <div class="field-items"> <b>Properties:</b>
     </p><div class="param">
      data (optional)
     </div>
@@ -17307,6 +17357,7 @@ RB = radio_buttons, RT = rectangles, S = dropdown, P = product_list, PI = produc
    </div>
   </div>
   <div class="model">
+   </p>
    <h3 class="field-label">
     <a name="ProductImagePost">
      ProductImagePost
@@ -17316,7 +17367,7 @@ RB = radio_buttons, RT = rectangles, S = dropdown, P = product_list, PI = produc
     The model for a POST to create an image on a product.
    </div>
    <br/>
-   <div class="field-items">
+   <div class="field-items"> <b>Properties:</b>
     </p><div class="param">
      is_thumbnail (optional)
     </div>
@@ -17375,6 +17426,7 @@ RB = radio_buttons, RT = rectangles, S = dropdown, P = product_list, PI = produc
    </div>
   </div>
   <div class="model">
+   </p>
    <h3 class="field-label">
     <a name="ProductImagePut">
      ProductImagePut
@@ -17384,7 +17436,7 @@ RB = radio_buttons, RT = rectangles, S = dropdown, P = product_list, PI = produc
     The model for a PUT to update applicable ProductImage fields.
    </div>
    <br/>
-   <div class="field-items">
+   <div class="field-items"> <b>Properties:</b>
     </p><div class="param">
      is_thumbnail (optional)
     </div>
@@ -17421,6 +17473,7 @@ RB = radio_buttons, RT = rectangles, S = dropdown, P = product_list, PI = produc
    </div>
   </div>
   <div class="model">
+   </p>
    <h3 class="field-label">
     <a name="ProductImageResponse">
      ProductImageResponse
@@ -17430,7 +17483,7 @@ RB = radio_buttons, RT = rectangles, S = dropdown, P = product_list, PI = produc
     Response payload for the Bigcommerce API.
    </div>
    <br/>
-   <div class="field-items">
+   <div class="field-items"> <b>Properties:</b>
     </p><div class="param">
      data (optional)
     </div>
@@ -17454,6 +17507,7 @@ RB = radio_buttons, RT = rectangles, S = dropdown, P = product_list, PI = produc
    </div>
   </div>
   <div class="model">
+   </p>
    <h3 class="field-label">
     <a name="ProductPost">
      ProductPost
@@ -17462,7 +17516,7 @@ RB = radio_buttons, RT = rectangles, S = dropdown, P = product_list, PI = produc
    <div class="model-description">
    </div>
    <br/>
-   <div class="field-items">
+   <div class="field-items"> <b>Properties:</b>
     </p><div class="param">
      id (optional)
     </div>
@@ -18133,6 +18187,7 @@ RB = radio_buttons, RT = rectangles, S = dropdown, P = product_list, PI = produc
    </div>
   </div>
   <div class="model">
+   </p>
    <h3 class="field-label">
     <a name="ProductPut">
      ProductPut
@@ -18141,7 +18196,7 @@ RB = radio_buttons, RT = rectangles, S = dropdown, P = product_list, PI = produc
    <div class="model-description">
    </div>
    <br/>
-   <div class="field-items">
+   <div class="field-items"> <b>Properties:</b>
     </p><div class="param">
      id (optional)
     </div>
@@ -18812,6 +18867,7 @@ RB = radio_buttons, RT = rectangles, S = dropdown, P = product_list, PI = produc
    </div>
   </div>
   <div class="model">
+   </p>
    <h3 class="field-label">
     <a name="ProductResponse">
      ProductResponse
@@ -18821,7 +18877,7 @@ RB = radio_buttons, RT = rectangles, S = dropdown, P = product_list, PI = produc
     Response payload for the Bigcommerce API.
    </div>
    <br/>
-   <div class="field-items">
+   <div class="field-items"> <b>Properties:</b>
     </p><div class="param">
      data (optional)
     </div>
@@ -18845,6 +18901,7 @@ RB = radio_buttons, RT = rectangles, S = dropdown, P = product_list, PI = produc
    </div>
   </div>
   <div class="model">
+   </p>
    <h3 class="field-label">
     <a name="ProductVideo">
      ProductVideo
@@ -18854,7 +18911,7 @@ RB = radio_buttons, RT = rectangles, S = dropdown, P = product_list, PI = produc
     A product video model.
    </div>
    <br/>
-   <div class="field-items">
+   <div class="field-items"> <b>Properties:</b>
     </p><div class="param">
      id (optional)
     </div>
@@ -18924,6 +18981,7 @@ RB = radio_buttons, RT = rectangles, S = dropdown, P = product_list, PI = produc
    </div>
   </div>
   <div class="model">
+   </p>
    <h3 class="field-label">
     <a name="ProductVideoCollectionResponse">
      ProductVideoCollectionResponse
@@ -18933,7 +18991,7 @@ RB = radio_buttons, RT = rectangles, S = dropdown, P = product_list, PI = produc
     Response payload for the Bigcommerce API.
    </div>
    <br/>
-   <div class="field-items">
+   <div class="field-items"> <b>Properties:</b>
     </p><div class="param">
      data (optional)
     </div>
@@ -18957,6 +19015,7 @@ RB = radio_buttons, RT = rectangles, S = dropdown, P = product_list, PI = produc
    </div>
   </div>
   <div class="model">
+   </p>
    <h3 class="field-label">
     <a name="ProductVideoResponse">
      ProductVideoResponse
@@ -18966,7 +19025,7 @@ RB = radio_buttons, RT = rectangles, S = dropdown, P = product_list, PI = produc
     Response payload for the Bigcommerce API.
    </div>
    <br/>
-   <div class="field-items">
+   <div class="field-items"> <b>Properties:</b>
     </p><div class="param">
      data (optional)
     </div>
@@ -18990,6 +19049,7 @@ RB = radio_buttons, RT = rectangles, S = dropdown, P = product_list, PI = produc
    </div>
   </div>
   <div class="model">
+   </p>
    <h3 class="field-label">
     <a name="ResourceImage">
      ResourceImage
@@ -18999,7 +19059,7 @@ RB = radio_buttons, RT = rectangles, S = dropdown, P = product_list, PI = produc
     An object containing a publicly accessible image URL, or a form post that contains an image file.
    </div>
    <br/>
-   <div class="field-items">
+   <div class="field-items"> <b>Properties:</b>
     </p><div class="param">
      image_url (optional)
     </div>
@@ -19014,6 +19074,7 @@ RB = radio_buttons, RT = rectangles, S = dropdown, P = product_list, PI = produc
    </div>
   </div>
   <div class="model">
+   </p>
    <h3 class="field-label">
     <a name="Subscriber">
      Subscriber
@@ -19022,7 +19083,7 @@ RB = radio_buttons, RT = rectangles, S = dropdown, P = product_list, PI = produc
    <div class="model-description">
    </div>
    <br/>
-   <div class="field-items">
+   <div class="field-items"> <b>Properties:</b>
     </p><div class="param">
      id (optional)
     </div>
@@ -19116,6 +19177,7 @@ RB = radio_buttons, RT = rectangles, S = dropdown, P = product_list, PI = produc
    </div>
   </div>
   <div class="model">
+   </p>
    <h3 class="field-label">
     <a name="SubscriberCollectionResponse">
      SubscriberCollectionResponse
@@ -19125,7 +19187,7 @@ RB = radio_buttons, RT = rectangles, S = dropdown, P = product_list, PI = produc
     Response payload for the Bigcommerce API.
    </div>
    <br/>
-   <div class="field-items">
+   <div class="field-items"> <b>Properties:</b>
     </p><div class="param">
      data (optional)
     </div>
@@ -19149,6 +19211,7 @@ RB = radio_buttons, RT = rectangles, S = dropdown, P = product_list, PI = produc
    </div>
   </div>
   <div class="model">
+   </p>
    <h3 class="field-label">
     <a name="SubscriberResponse">
      SubscriberResponse
@@ -19158,7 +19221,7 @@ RB = radio_buttons, RT = rectangles, S = dropdown, P = product_list, PI = produc
     Response payload for the Bigcommerce API.
    </div>
    <br/>
-   <div class="field-items">
+   <div class="field-items"> <b>Properties:</b>
     </p><div class="param">
      data (optional)
     </div>
@@ -19182,6 +19245,7 @@ RB = radio_buttons, RT = rectangles, S = dropdown, P = product_list, PI = produc
    </div>
   </div>
   <div class="model">
+   </p>
    <h3 class="field-label">
     <a name="Variant">
      Variant
@@ -19190,7 +19254,7 @@ RB = radio_buttons, RT = rectangles, S = dropdown, P = product_list, PI = produc
    <div class="model-description">
    </div>
    <br/>
-   <div class="field-items">
+   <div class="field-items"> <b>Properties:</b>
     </p><div class="param">
      id (optional)
     </div>
@@ -19356,6 +19420,7 @@ RB = radio_buttons, RT = rectangles, S = dropdown, P = product_list, PI = produc
    </div>
   </div>
   <div class="model">
+   </p>
    <h3 class="field-label">
     <a name="VariantCollectionResponse">
      VariantCollectionResponse
@@ -19365,7 +19430,7 @@ RB = radio_buttons, RT = rectangles, S = dropdown, P = product_list, PI = produc
     Response payload for the Bigcommerce API.
    </div>
    <br/>
-   <div class="field-items">
+   <div class="field-items"> <b>Properties:</b>
     </p><div class="param">
      data (optional)
     </div>
@@ -19389,6 +19454,7 @@ RB = radio_buttons, RT = rectangles, S = dropdown, P = product_list, PI = produc
    </div>
   </div>
   <div class="model">
+   </p>
    <h3 class="field-label">
     <a name="VariantPost">
      VariantPost
@@ -19397,7 +19463,7 @@ RB = radio_buttons, RT = rectangles, S = dropdown, P = product_list, PI = produc
    <div class="model-description">
    </div>
    <br/>
-   <div class="field-items">
+   <div class="field-items"> <b>Properties:</b>
     </p><div class="param">
      id (optional)
     </div>
@@ -19562,6 +19628,7 @@ RB = radio_buttons, RT = rectangles, S = dropdown, P = product_list, PI = produc
    </div>
   </div>
   <div class="model">
+   </p>
    <h3 class="field-label">
     <a name="VariantResponse">
      VariantResponse
@@ -19571,7 +19638,7 @@ RB = radio_buttons, RT = rectangles, S = dropdown, P = product_list, PI = produc
     Successful response
    </div>
    <br/>
-   <div class="field-items">
+   <div class="field-items"> <b>Properties:</b>
     </p><div class="param">
      data (optional)
     </div>
@@ -19595,7 +19662,7 @@ RB = radio_buttons, RT = rectangles, S = dropdown, P = product_list, PI = produc
    </div>
   </div>
 
-<h2 class="jumptarget"> <a name="definitions"></a> Definitions </h2>
+<h2 id="definitions" class="jumptarget"> Definitions </h2>
 
 <div id="integer"> <b>Integer:</b> A whole number. </div>
 

--- a/source/includes/_v3_catalog_customer_complete.md
+++ b/source/includes/_v3_catalog_customer_complete.md
@@ -13202,9 +13202,9 @@ Values: id, name, sku, price, date_modified, date_last_imported, inventory_level
     Up
    </a>
   </div>
-  <h2 id="__Models" class="jumptarget">
+  <h1 id="__Models" class="jumptarget">
     Models – Contents
-  </h2>
+  </h1>
   [ Jump to
   <a href="#__Methods">
    Methods


### PR DESCRIPTION
(1) Groomed v3 swagger export (in ‘/drafts/‘) to look Slatelike,
professional, & “baked.”
(2) Corrected malformed links in OAuth Tokens topic.
(3) Added note to Blueprint > Checkout Styling that “Stencil”-named
functions are actually  compatible with Blueprint themes.