### PR TITLE
Updated Blueprint > cp access blurb

### DIFF
--- a/source/includes/_themes_blueprint.md
+++ b/source/includes/_themes_blueprint.md
@@ -1,10 +1,20 @@
 # <span class="jumptarget"> Blueprint and Developer Mode </span>
 
-## <span class="jumptarget"> A Foundation for Creating Great Themes </span>
 
-When you are creating a new theme, our Blueprint  base theme makes a great starting point. Blueprint includes responsive support out-of-the-box, so it works with lower resolutions like those on mobile devices. The visual design has been stripped back, so you can create from a clean canvas.
+<aside class="warning">
+<span class="aside-warning-hd"> Restricted/Grandfathered Access</span><br><br>
+As of November 2016, new BigCommerce stores are being offered themes exclusively from BigCommerce's new <a href="https://support.bigcommerce.com/articles/Public/The-Stencil-Theme-Platform" target="_blank">Stencil</a> theme platform. For existing stores, the control panel's <NOBR><b>Themes Marketplace</b></nobr> and <NOBR><b>My Themes</b></nobr> pages will show only those Blueprint themes that have been applied to the store and/or purchased before November 2016. <br><br> 
+
+This means that the workflow below will work only for stores that have applied or purchased at least one Blueprint theme before November 2016. For information about developing on the current Stencil platform, please see <a href="https://stencil.bigcommerce.com/docs/" target="_blank">this developer documentation</a>.
+</aside>
+
+
+## <span class="jumptarget"> A Foundation for Creating Themes </span>
+
+Our (legacy) Blueprint "Classic Next" base theme provides a starting point for creating a new theme. This theme includes responsive support out-of-the-box, so it works with lower resolutions like those on mobile devices. The visual design has been stripped back, so you can create from a clean canvas.
 
 <a href="https://blueprint-demo.mybigcommerce.com" target="_blank">View the demo</a>.
+
 
 ## <span class="jumptarget"> Setting Up Your Environment </span>
 
@@ -12,7 +22,7 @@ Follow these steps to start developing using the Blueprint theme:
 
 1.  To enable the Blueprint theme on your store, simply log in to the control panel, and place <NOBR>`/index.php?ToDo=viewTemplates&dev=enable` </nobr>after `/admin`.<br>
     (For example: <NOBR>`https://store-123abmy.mybigcommerce.com/admin/index.php?ToDo=viewTemplates&dev=enable`.</nobr>)
-2.  Apply the Blueprint theme
+2.  Apply the Blueprint theme.
 3.  Connect to the site via <a href="https://support.bigcommerce.com/articles/Public/Connecting-to-WebDav/" target="_blank">WebDAV</a>.
 4.  Once connected via WebDav, navigate to the `/template/` folder, where you will have access to all the files that make up a theme.
 5.  To make a change to a file, just download the file, edit it, and then upload your altered version.


### PR DESCRIPTION
* Added callout that Blueprint themes are visible in a store’s cp only
if acquired before November 2016.

* Scaled back marketese claims about Blueprint; added links to Stencil
KB and developer docs.