### PR TITLE
Changelog fixes

### DIFF
--- a/source/includes/_changelog_2017.md
+++ b/source/includes/_changelog_2017.md
@@ -16,7 +16,7 @@ For developers who want to exercise BigCommerce APIs without (or prior to) build
 
 ### <span class="jumptarget"> Stencil Repo Adds Onboard Changelog </span>
 
-<b>2017-02-07:</b> The Stencil public repository now maintains its own changelog, at 
+<b>2017-02-07:</b> The Stencil public repository now maintains its own changelog, at:     
 [https://github.com/bigcommerce/stencil/blob/master/CHANGELOG.md](https://github.com/bigcommerce/stencil/blob/master/CHANGELOG.md). (Stencil-3000; PR # 919)
 
 

--- a/source/stylesheets/_custom.scss
+++ b/source/stylesheets/_custom.scss
@@ -127,13 +127,20 @@
     margin-bottom: 0 !important;
   }
 
-  h2, h3, h4, h5, h6 {
+  h2 {
+    /* Isolated 2/17/17, needs extra leading: */
+    margin-top: 28px !important;
+    margin-bottom: 22px !important;
+  }
+
+  /* h2,*/  h3, h4, h5, h6 {
     margin-top: 0;
     margin-bottom: 11px;
   }
 
   h3, h4 {
-    padding-top: 2%;
+    /* Removed 2/17/17, exaggerates leading: */
+    /* padding-top: 2%; */
   }
 }
 


### PR DESCRIPTION
* Adjusted one-off line break.

* CSS fix for headings: h3’s had excessive leading; h2’s had too little. Adjusted both, to restore original visual balance and easy readability.